### PR TITLE
Adding isort

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -157,8 +157,10 @@ jobs:
         python-version: "3.10"
         architecture: x64
     - name: Install dependencies
-      run: python -m pip install -U pip black pyupgrade
+      run: python -m pip install -U pip black pyupgrade isort
     - name: Check Python Formatting
       run: black --check .
+    - name: Check Python import sorting
+      run: isort --check .
     - name: Check pyupgrade
       run: pyupgrade --py37-plus src/picologging/*.py tests/**/*.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,8 @@ repos:
     hooks:
     -   id: pyupgrade
         args: ['--py37-plus']
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)

--- a/benchmarks/bench_handlers.py
+++ b/benchmarks/bench_handlers.py
@@ -1,10 +1,11 @@
-import tempfile
-import logging
-import picologging
-import logging.handlers as logging_handlers
-import picologging.handlers as picologging_handlers
-import queue
 import io
+import logging
+import logging.handlers as logging_handlers
+import queue
+import tempfile
+
+import picologging
+import picologging.handlers as picologging_handlers
 
 
 def filehandler_logging():

--- a/benchmarks/bench_logger.py
+++ b/benchmarks/bench_logger.py
@@ -1,5 +1,6 @@
-from io import StringIO
 import logging
+from io import StringIO
+
 import picologging
 
 logging.basicConfig()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,6 @@ environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 
 [tool.pylint.messages_control]
 disable = "C0114,C0115,C0116"
+
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
-from skbuild import setup
 from setuptools import find_packages
-
+from skbuild import setup
 
 with open("./README.md") as fh:
     long_description = fh.read()

--- a/slowtests/test_logrecordhyp.py
+++ b/slowtests/test_logrecordhyp.py
@@ -2,8 +2,9 @@ import logging
 import sys
 
 import pytest
-from hypothesis import given, reproduce_failure, strategies as st
 from flaky import flaky
+from hypothesis import given, reproduce_failure
+from hypothesis import strategies as st
 
 import picologging
 

--- a/src/picologging/__init__.py
+++ b/src/picologging/__init__.py
@@ -1,23 +1,19 @@
-import sys
+import io
 import os
+import sys
+import warnings
+from logging import BufferingFormatter, Filter, StringTemplateStyle, _checkLevel
+
+from ._picologging import Handler  # NOQA
 from ._picologging import (
-    LogRecord,
+    Filterer,
     FormatStyle,
     Formatter,
     Logger,
-    Filterer,
-    Handler,
+    LogRecord,
     StreamHandler,
     getLevelName,
-)  # NOQA
-from logging import (
-    _checkLevel,
-    Filter,
-    StringTemplateStyle,
-    BufferingFormatter,
 )
-import io
-import warnings
 
 __version__ = "0.8.1"
 

--- a/src/picologging/__init__.pyi
+++ b/src/picologging/__init__.pyi
@@ -1,10 +1,11 @@
-from _typeshed import StrPath, SupportsWrite
 from collections.abc import Callable, Iterable, Mapping
 from io import TextIOWrapper
 from multiprocessing import Manager
 from string import Template
 from types import TracebackType
-from typing import Any, Generic, Pattern, TextIO, TypeVar, Union, overload, Optional
+from typing import Any, Generic, Optional, Pattern, TextIO, TypeVar, Union, overload
+
+from _typeshed import StrPath, SupportsWrite
 from typing_extensions import Literal, TypeAlias
 
 CRITICAL: int

--- a/src/picologging/handlers.py
+++ b/src/picologging/handlers.py
@@ -1,11 +1,12 @@
-import queue
 import os
 import pickle
+import queue
 import re
 import socket
 import struct
-import time
 import threading
+import time
+
 import picologging
 
 _MIDNIGHT = 24 * 60 * 60  # number of seconds in a day

--- a/src/picologging/handlers.pyi
+++ b/src/picologging/handlers.pyi
@@ -1,10 +1,11 @@
 from datetime import datetime
-from typing import Any, Callable, Pattern
-from _typeshed import StrPath
 from queue import Queue, SimpleQueue
 from socket import socket
+from typing import Any, Callable, Pattern
 
-from picologging import Handler, FileHandler, LogRecord
+from _typeshed import StrPath
+
+from picologging import FileHandler, Handler, LogRecord
 
 class WatchedFileHandler(FileHandler):
     baseFilename: str  # undocumented

--- a/tests/fuzzing/fuzz_atheris.py
+++ b/tests/fuzzing/fuzz_atheris.py
@@ -1,9 +1,11 @@
-import atheris
 import io
 
+import atheris
+
 with atheris.instrument_imports():
-    import picologging
     import sys
+
+    import picologging
 
     picologging.basicConfig()
     logger = picologging.Logger("fuzz", picologging.DEBUG)

--- a/tests/memray/memray_format_exception.py
+++ b/tests/memray/memray_format_exception.py
@@ -1,5 +1,6 @@
-from picologging import Formatter
 import sys
+
+from picologging import Formatter
 
 
 def test_format_exception():

--- a/tests/memray/memray_logger.py
+++ b/tests/memray/memray_logger.py
@@ -2,8 +2,9 @@
 Create 100,000  logger instances and run a log test on them
 """
 
-import picologging
 from io import StringIO
+
+import picologging
 
 
 def log(level=picologging.INFO):

--- a/tests/memray/memray_logrecord.py
+++ b/tests/memray/memray_logrecord.py
@@ -1,5 +1,6 @@
-import picologging
 from io import StringIO
+
+import picologging
 
 
 def log(level=picologging.INFO):

--- a/tests/profile/profile.py
+++ b/tests/profile/profile.py
@@ -1,5 +1,6 @@
-import picologging
 from io import StringIO
+
+import picologging
 
 
 def run_profile(level=picologging.DEBUG):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,5 @@
 import pytest
+
 import picologging
 from picologging.config import dictConfig, valid_ident
 

--- a/tests/unit/test_filehandler.py
+++ b/tests/unit/test_filehandler.py
@@ -7,9 +7,9 @@ import pytest
 
 import picologging
 from picologging.handlers import (
-    WatchedFileHandler,
     RotatingFileHandler,
     TimedRotatingFileHandler,
+    WatchedFileHandler,
 )
 
 

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,8 +1,10 @@
-from picologging import Formatter, LogRecord
+import datetime
 import logging
 import sys
+
 import pytest
-import datetime
+
+from picologging import Formatter, LogRecord
 
 
 def test_formatter_default_fmt():

--- a/tests/unit/test_handler.py
+++ b/tests/unit/test_handler.py
@@ -1,5 +1,6 @@
-import picologging
 import pytest
+
+import picologging
 
 
 def test_basic_handler():

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,8 +1,10 @@
 import io
-import uuid
-import picologging
 import logging
+import uuid
+
 import pytest
+
+import picologging
 
 
 def test_logger_attributes():

--- a/tests/unit/test_logrecord.py
+++ b/tests/unit/test_logrecord.py
@@ -1,9 +1,11 @@
-import threading
-from picologging import LogRecord
-import picologging
 import logging
-import pytest
 import os
+import threading
+
+import pytest
+
+import picologging
+from picologging import LogRecord
 
 
 def test_logrecord_standard():

--- a/tests/unit/test_percentstyle.py
+++ b/tests/unit/test_percentstyle.py
@@ -1,7 +1,9 @@
-from picologging import PercentStyle, LogRecord, INFO
-import pytest
-import threading
 import logging
+import threading
+
+import pytest
+
+from picologging import INFO, LogRecord, PercentStyle
 
 
 def test_percentstyle():

--- a/tests/unit/test_picologging.py
+++ b/tests/unit/test_picologging.py
@@ -1,7 +1,9 @@
-import sys
-import picologging
 import logging
+import sys
+
 import pytest
+
+import picologging
 
 levels = [
     (picologging.DEBUG, "DEBUG"),

--- a/tests/unit/test_queuehandler.py
+++ b/tests/unit/test_queuehandler.py
@@ -1,7 +1,8 @@
-from picologging.handlers import QueueHandler, QueueListener
-import picologging
-import queue
 import io
+import queue
+
+import picologging
+from picologging.handlers import QueueHandler, QueueListener
 
 
 def test_queue_handler_dispatch():

--- a/tests/unit/test_sockethandler.py
+++ b/tests/unit/test_sockethandler.py
@@ -6,8 +6,8 @@ import tempfile
 import threading
 from socketserver import (
     DatagramRequestHandler,
-    ThreadingTCPServer,
     StreamRequestHandler,
+    ThreadingTCPServer,
     ThreadingUDPServer,
 )
 

--- a/tests/unit/test_streamhandler.py
+++ b/tests/unit/test_streamhandler.py
@@ -1,7 +1,9 @@
 import io
 import sys
-import picologging
+
 import pytest
+
+import picologging
 
 
 def test_stream_handler():

--- a/tests/unit/test_strformatstyle.py
+++ b/tests/unit/test_strformatstyle.py
@@ -1,7 +1,9 @@
-from picologging import Formatter, StrFormatStyle, LogRecord, INFO
-import pytest
-import threading
 import logging
+import threading
+
+import pytest
+
+from picologging import INFO, Formatter, LogRecord, StrFormatStyle
 
 
 def test_strformatstyle():

--- a/tests/unit/test_threading.py
+++ b/tests/unit/test_threading.py
@@ -1,7 +1,8 @@
+import io
 import threading
+
 import picologging
 from picologging import Logger, StreamHandler
-import io
 
 
 def test_threaded_execution():


### PR DESCRIPTION
As suggested in #110, this PR adds isort in pre-commit and the quality workflow, and runs it on all the existing files.

Since black and isort's defaults disagree, I added configuration to make isort follow the black conventions.